### PR TITLE
[CI] Run CI on a schedule

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,6 +6,10 @@ name: Python
 on:
   push:
   pull_request:
+  schedule:
+    # Run daily at 00:00 so we get notified if CI is broken before a pull request is submitted. 
+    # It also notifies us about new Arrow releases for which we need to release a corresponding version of PalletJack.
+    - cron:  '0 0 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
Running CI script on a schedule will achieve two goals.
- We will get notified about any GH environment changes affecting the CI
- We will get detection of new releases of Arrow for wich we need to release a new version of PalletJack
