### PR TITLE
CI should work for scheduled runs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,7 +5,9 @@ name: Python
 
 on:
   push:
+    branches: [ master ]
   pull_request:
+    branches: [ master ]
   schedule:
     # Run daily at 00:00 so we get notified if CI is broken before a pull request is submitted. 
     # It also notifies us about new Arrow releases for which we need to release a corresponding version of PalletJack.
@@ -17,7 +19,6 @@ permissions:
 jobs:
         
   test:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -50,7 +51,6 @@ jobs:
 
   build:
     needs: test
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,9 +5,7 @@ name: Python
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
   schedule:
     # Run daily at 00:00 so we get notified if CI is broken before a pull request is submitted. 
     # It also notifies us about new Arrow releases for which we need to release a corresponding version of PalletJack.
@@ -19,6 +17,7 @@ permissions:
 jobs:
         
   test:
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -51,6 +50,7 @@ jobs:
 
   build:
     needs: test
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
Currently, scheduled workflows are skipped.
I don't know any drawbacks of the change proposed in this PR, but if there are any we can either use the same pattern as in ParquetSharp (https://github.com/G-Research/ParquetSharp/blob/master/.github/workflows/ci.yml#L24).