### PR TITLE
Fix the problem with building thrift

### DIFF
--- a/python/vcpkg.json
+++ b/python/vcpkg.json
@@ -4,5 +4,5 @@
   "dependencies": [
     "thrift"
   ],
-  "builtin-baseline": "943c5ef1c8f6b5e6ced092b242c8299caae2ff01"
+  "builtin-baseline": "1de2026f28ead93ff1773e6e680387643e914ea1"
 }


### PR DESCRIPTION
It is not entirely clear to me why thrift compilation stopped working. After bumping the vcpkg's  baseline version it works again.