### PR TITLE
Workaround for CI failures

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get install -y libthrift-dev libboost-all-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest build pytest
+        pip install flake8 pytest
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get install -y libthrift-dev libboost-all-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest cibuildwheel==2.19.2 build pytest
+        pip install flake8 pytest build pytest
 
     - name: Lint with flake8
       run: |
@@ -70,7 +70,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest cibuildwheel build
+        pip install flake8 pytest cibuildwheel==2.19.2 build
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -137,7 +137,7 @@ jobs:
         # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 
         # Disable unsupported builds
-        CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32 cp13-*"
+        CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32 cp313-*"
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -33,7 +33,7 @@ jobs:
         sudo apt-get install -y libthrift-dev libboost-all-dev
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest cibuildwheel build pytest
+        pip install flake8 pytest cibuildwheel==2.19.2 build pytest
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install flake8 pytest cibuildwheel==2.19.2 build
+        pip install flake8 pytest cibuildwheel build
 
     # Compute vcpkg triplet and root
     - name: Compute vcpkg triplet and root
@@ -137,7 +137,7 @@ jobs:
         # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 
         # Disable unsupported builds
-        CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32"
+        CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32 cp13-*"
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
There is no `cp313` binary package for PyArrow, thus we need to exclude from list of versions to be build..