### PR TITLE
Updating Arrow version in the README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ PalletJack reduces the amount of metadata bytes that need to be read and decoded
 
 ## Required:
 
-- pyarrow  ~= 16.0
+- pyarrow  ~= 18.1.0
  
 PalletJack operates on top of pyarrow, making it an essential requirement for both building and using PalletJack. While our source package is compatible with recent versions of pyarrow, the binary distribution package specifically requires the latest major version of pyarrow.
 


### PR DESCRIPTION
I missed that when upgrading the arrow version.