### PR TITLE
Explicit errors message when arrow version mismatch

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -6,4 +6,5 @@ __pycache__
 vcpkg_installed
 .vscode
 /palletjack/palletjack_cython.cpp
+/palletjack/package_metadata.py
 cython_debug

--- a/python/palletjack/__init__.py
+++ b/python/palletjack/__init__.py
@@ -1,3 +1,15 @@
 # Importing pyarrow is necessary to load the runtime libraries
+import pyarrow
 import pyarrow.parquet
-from .palletjack_cython import *
+from importlib.metadata import version, requires
+__version__ = version(__package__)  # Uses package metadata
+dependencies = requires(__package__)
+pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
+
+try:
+    from .palletjack_cython import *
+except ImportError as e:
+    if any(x in str(e) for x in ['arrow', 'parquet']):
+        raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}. ({str(e)})") from None
+    else:
+        raise

--- a/python/palletjack/__init__.py
+++ b/python/palletjack/__init__.py
@@ -1,15 +1,17 @@
 # Importing pyarrow is necessary to load the runtime libraries
 import pyarrow
 import pyarrow.parquet
-from importlib.metadata import version, requires
-__version__ = version(__package__)  # Uses package metadata
-dependencies = requires(__package__)
-pyarrow_req = next((r for r in dependencies if r.startswith('pyarrow')), '')
+
+from .package_metadata import (
+    __version__,
+    __dependencies__
+)
 
 try:
     from .palletjack_cython import *
 except ImportError as e:
     if any(x in str(e) for x in ['arrow', 'parquet']):
+        pyarrow_req = next((r for r in __dependencies__ if r.startswith('pyarrow')), '')
         raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}. ({str(e)})") from None
     else:
         raise

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palletjack"
-version = "2.5.0"
+version = "2.5.1"
 description = "Faster parquet metadata reading"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Improving exception message when PalletJack fails to import arrow libraries. 
We generate a Python file with package metadata at build time so it works independently of how the package is installed. 

- Before:
```
Traceback (most recent call last):
  File "/workspace/PalletJack/python/test/test_palletjack.py", line 4, in <module>
    import palletjack as pj
  File "/workspace/PalletJack/python/palletjack/__init__.py", line 3, in <module>
    from .palletjack_cython import *
ImportError: libarrow.so.1900: cannot open shared object file: No such file or directory
```

- After:
```
Traceback (most recent call last):
  File "/workspace/PalletJack/python/test/test_palletjack.py", line 4, in <module>
    import palletjack as pj
  File "/workspace/PalletJack/python/palletjack/__init__.py", line 13, in <module>
    raise ImportError(f"This version of {__package__}={__version__} is built against {pyarrow_req}, please ensure you have it installed. Current pyarrow version is {pyarrow.__version__}. ({str(e)})") from None
ImportError: This version of palletjack=2.5.0 is built against pyarrow~=19.0.0, please ensure you have it installed. Current pyarrow version is 18.0.0. (libarrow.so.1900: cannot open shared object file: No such file or directory)
```