### PR TITLE
Improving glibc/ABI compatibility - align with pyarrow

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install dependencies
       working-directory: ./python
@@ -53,7 +53,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        # macos-13 doesn't work
         runner: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-latest]
       fail-fast: false
 
@@ -130,6 +129,7 @@ jobs:
       matrix:
         python-version: ["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313"]
       fail-fast: false
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -230,7 +230,6 @@ jobs:
       id-token: write
 
     steps:
-
     - name: Download artifacts
       uses: actions/download-artifact@v5
       with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -150,6 +150,7 @@ jobs:
             -t palletjack-test-py${{ matrix.python-version }} \
             --progress plain \
             -f Dockerfile.test .
+          docker run palletjack-test-py${{ matrix.python-version }}
 
   # Virtual job that can be configured as a required check before a PR can be merged.
   # As GitHub considers a check as successful if it is skipped, we need to check its status in

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,7 +48,7 @@ jobs:
         pip install --editable .
         pytest
 
-  build:
+  build-binary:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -180,7 +180,7 @@ jobs:
     name: All required checks done
     needs:
       - test
-      - build
+      - build-binary
       - test-binary
       - test-binary-manylinux
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -135,6 +135,7 @@ jobs:
         uses: actions/checkout@v4
   
       - name: Download artifacts
+        working-directory: ./python
         uses: actions/download-artifact@v5
         with:
           pattern: dist-*
@@ -142,36 +143,14 @@ jobs:
           merge-multiple: true
   
       - name: Build and Run Docker Container for Tests
+        working-directory: ./python
         run: |
-          # Create a temporary Dockerfile for our testing environment
-          cat <<EOF > Dockerfile.test
-          FROM quay.io/pypa/manylinux_2_28
-  
-          # Set a working directory
-          WORKDIR /app
-          COPY . .
-
-          # Install and test with Python ${{ matrix.python-version }}
-          RUN /opt/python/${{ matrix.python-version }}/bin/pip install -r python/requirements.txt
-
-          # Install the package from local dist directory
-          RUN /opt/python/${{ matrix.python-version }}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all:
-
-          # Force reinstall to ensure local version is used
-          RUN /opt/python/${{ matrix.python-version }}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
-
-          # Print the GLIBC version
-          RUN ldd --version
-
-          # Define the command to run tests
-          CMD ["/opt/python/${{ matrix.python-version }}/bin/python", "python/test/test_palletjack.py"]
-          EOF
-
-          # Build the Docker image
-          docker build -t palletjack-test-py${{ matrix.python-version }} -f Dockerfile.test .
-
-          # Run the Docker container
-          docker run palletjack-test-py${{ matrix.python-version }}
+          # Build the Docker image with Python version as build arg
+          docker build \
+            --build-arg PYTHON_VERSION=${{ matrix.python-version }} \
+            -t palletjack-test-py${{ matrix.python-version }} \
+            --progress plain \
+            -f Dockerfile.test .
 
   # Virtual job that can be configured as a required check before a PR can be merged.
   # As GitHub considers a check as successful if it is skipped, we need to check its status in

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -135,11 +135,10 @@ jobs:
         uses: actions/checkout@v4
   
       - name: Download artifacts
-        working-directory: ./python
         uses: actions/download-artifact@v5
         with:
           pattern: dist-*
-          path: dist
+          path: python/dist
           merge-multiple: true
   
       - name: Build and Run Docker Container for Tests

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,7 +48,7 @@ jobs:
         pip install --editable .
         pytest
 
-  build-binary:
+  build-wheels:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -89,7 +89,7 @@ jobs:
         path: ./python/dist/*
 
   test-binary:
-    needs: build
+    needs: build-wheels
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -123,7 +123,7 @@ jobs:
         python3 python/test/test_palletjack.py
 
   test-binary-manylinux:
-    needs: build
+    needs: build-wheels
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -180,7 +180,7 @@ jobs:
     name: All required checks done
     needs:
       - test
-      - build-binary
+      - build-wheels
       - test-binary
       - test-binary-manylinux
     runs-on: ubuntu-latest
@@ -188,7 +188,7 @@ jobs:
       - run: echo "All required checks done"
 
   benchmarks:
-    needs: build
+    needs: build-wheels
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,7 +7,7 @@ on:
   push:
   pull_request:
   schedule:
-    # Run daily at 00:00 so we get notified if CI is broken before a pull request is submitted. 
+    # Run daily at 00:00 so we get notified if CI is broken before a pull request is submitted.
     # It also notifies us about new Arrow releases for which we need to release a corresponding version of PalletJack.
     - cron:  '0 0 * * *'
 
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-        
+
   test:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-        
+
     - name: Install dependencies
       working-directory: ./python
       shell: bash
@@ -45,106 +45,44 @@ jobs:
     - name: Test with pytest
       working-directory: ./python
       run: |
-        pip install --editable . 
+        pip install --editable .
         pytest
 
   build:
-    needs: test
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        include:
-          - runner: ubuntu-latest
-            arch: x64
-          - runner: windows-latest
-            arch: x64
-          - runner: ubuntu-22.04-arm64
-            arch: arm64
+        # macos-13 doesn't work
+        runner: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-latest]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
-        
-    - name: Install dependencies
-      working-directory: ./python
-      shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install flake8 pytest cibuildwheel build
+        python-version: "3.12"
 
-    # Compute vcpkg triplet and root
-    - name: Compute vcpkg triplet and root
-      id: vcpkg-info
-      run: |
-        triplet="${{ matrix.arch }}-"
-        case ${{ runner.os }} in
-          Linux)
-            triplet+="linux"
-            ;;
-          macOS)
-            triplet+="osx"
-            ;;
-          Windows)
-            triplet+="windows"
-            ;;
-        esac
-        echo "triplet=$triplet" >> $GITHUB_OUTPUT
-        echo "root=$VCPKG_INSTALLATION_ROOT" >> $GITHUB_OUTPUT
-        echo "cmake_version=$(cmake --version | head -n1 | awk '{print $3}')" >> $GITHUB_OUTPUT
-        echo "runner_info=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
-      shell: bash
-      
-    - uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
       if: runner.os == 'macOS'
       run: brew install bison
 
-    - name: Install thrift
-      working-directory: ./python
-      run: |
-        vcpkg install --triplet ${{ steps.vcpkg-info.outputs.triplet }} --x-manifest-root . --feature-flags=versions
-      env:
-        VCPKG_BINARY_SOURCES: clear;x-gha,readwrite
-
-    - name: Upload vcpkg arrow logs
-      if: success() || failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ steps.vcpkg-info.outputs.triplet }}-vcpkg-arrow-logs
-        path: ${{ steps.vcpkg-info.outputs.root }}/buildtrees/arrow/*.log
-
     - name: Build sdist (Linux)
       if: runner.os == 'linux'
       working-directory: ./python
       run: |
-        python -m build --sdist         
-        
+        pip install build
+        python -m build --sdist
+
     - name: Build wheels
       working-directory: ./python
-      run: python -m cibuildwheel --output-dir dist
-      # to supply options, put them in 'env', like:
+      run: |
+        pip install cibuildwheel
+        cibuildwheel --output-dir dist
       env:
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.2100 --exclude libparquet.so.2100 -w {dest_dir} {wheel}
-        CIBW_ENVIRONMENT: VCPKG_TARGET_TRIPLET="${{ steps.vcpkg-info.outputs.triplet }}"
         CIBW_BUILD_VERBOSITY: 1
-        # We use manylinux_2_28 for ABI compatibility with pyarrow
-        # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 
-        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-        # Disable unsupported builds
-        CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32 cp313-*"
 
     - uses: actions/upload-artifact@v4
       with:
@@ -156,13 +94,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        include:
-          - runner: ubuntu-latest
-            arch: x64
-          - runner: windows-latest
-            arch: x64
-          - runner: ubuntu-22.04-arm64
-            arch: arm64
+        runner: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-latest]
       fail-fast: false
 
     steps:
@@ -178,15 +110,68 @@ jobs:
         pattern: dist-*
         path: dist
         merge-multiple: true
-          
-    - name: Test with pytest
+
+    - name: Test binary
       run: |
         pip install -r python/requirements.txt
+
         # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        # So now ensure that the local version is installed 
+
+        # So now ensure that the local version is installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
+
         python3 python/test/test_palletjack.py
+
+  test-binary-manylinux:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["cp39-cp39", "cp310-cp310", "cp311-cp311", "cp312-cp312", "cp313-cp313"]
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+  
+      - name: Download artifacts
+        uses: actions/download-artifact@v5
+        with:
+          pattern: dist-*
+          path: dist
+          merge-multiple: true
+  
+      - name: Build and Run Docker Container for Tests
+        run: |
+          # Create a temporary Dockerfile for our testing environment
+          cat <<EOF > Dockerfile.test
+          FROM quay.io/pypa/manylinux_2_28
+  
+          # Set a working directory
+          WORKDIR /app
+          COPY . .
+
+          # Install and test with Python ${{ matrix.python-version }}
+          RUN /opt/python/${{ matrix.python-version }}/bin/pip install -r python/requirements.txt
+
+          # Install the package from local dist directory
+          RUN /opt/python/${{ matrix.python-version }}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all:
+
+          # Force reinstall to ensure local version is used
+          RUN /opt/python/${{ matrix.python-version }}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
+
+          # Print the GLIBC version
+          RUN ldd --version
+
+          # Define the command to run tests
+          CMD ["/opt/python/${{ matrix.python-version }}/bin/python", "python/test/test_palletjack.py"]
+          EOF
+
+          # Build the Docker image
+          docker build -t palletjack-test-py${{ matrix.python-version }} -f Dockerfile.test .
+
+          # Run the Docker container
+          docker run palletjack-test-py${{ matrix.python-version }}
 
   # Virtual job that can be configured as a required check before a PR can be merged.
   # As GitHub considers a check as successful if it is skipped, we need to check its status in
@@ -197,6 +182,7 @@ jobs:
       - test
       - build
       - test-binary
+      - test-binary-manylinux
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required checks done"
@@ -206,13 +192,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        include:
-          - runner: ubuntu-latest
-            arch: x64
-          - runner: windows-latest
-            arch: x64
-          - runner: ubuntu-22.04-arm64
-            arch: arm64
+        runner: [ubuntu-latest, windows-latest, ubuntu-22.04-arm64, macos-latest]
       fail-fast: false
 
     steps:
@@ -232,10 +212,13 @@ jobs:
     - name: Run benchmarks
       run: |
         pip install -r python/requirements.txt
+
         # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        # So now ensure that the local version is installed 
+
+        # So now ensure that the local version is installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
+
         python3 ./benchmarks/benchmark_palletjack_metadata.py
 
   publish:
@@ -254,25 +237,24 @@ jobs:
         pattern: dist-*
         path: dist
         merge-multiple: true
-    
+
     - name: Display structure of downloaded files
       run: ls -R dist
-    
+
     - name: Validate tag
       shell: pwsh
       run: |
         $tag = "${{ github.ref }}".SubString(11)
         $expectedFile = "dist/palletjack-$tag.tar.gz"
-    
+
         # Check whether the tag and the package version match together
         if (-not (Test-Path -Path $expectedFile)) {
             echo "::error ::Expected file $expectedFile doesn't exist"
             Get-ChildItem -Path dist
             exit 1
         }
-    
+
     - name: Publish to PyPi
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
       with:
-        packages-dir: dist	
-    
+        packages-dir: dist

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -1,0 +1,22 @@
+FROM quay.io/pypa/manylinux_2_28
+  
+# Set a working directory
+WORKDIR /app
+COPY . .
+
+ARG PYTHON_VERSION="cp39-cp39"
+
+# Print the GLIBC version
+RUN ldd --version && \
+
+# Install and test with Python ${PYTHON_VERSION}
+   /opt/python/${PYTHON_VERSION}/bin/pip install -r ./requirements.txt && \
+
+# Install the package from local dist directory
+   /opt/python/${PYTHON_VERSION}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: && \
+
+# Force reinstall to ensure local version is used
+   /opt/python/${PYTHON_VERSION}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
+
+# Define the command to run tests
+RUN /opt/python/${PYTHON_VERSION}/bin/python ./test/test_palletjack.py 

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -19,4 +19,4 @@ RUN ldd --version && \
    /opt/python/${PYTHON_VERSION}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
 
 # Define the command to run tests
-CMD ["/opt/python/${PYTHON_VERSION}/bin/python", "./test/test_palletjack.py "]
+CMD ["/opt/python/${PYTHON_VERSION}/bin/python", "./test/test_palletjack.py"]

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -19,4 +19,4 @@ RUN ldd --version && \
    /opt/python/${PYTHON_VERSION}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
 
 # Define the command to run tests
-RUN /opt/python/${PYTHON_VERSION}/bin/python ./test/test_palletjack.py 
+CMD ["/opt/python/${PYTHON_VERSION}/bin/python", "./test/test_palletjack.py "]

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -6,6 +6,10 @@ COPY . .
 
 ARG PYTHON_VERSION="cp39-cp39"
 
+# Set PYTHON_VERSION as an environment variable.
+£ See https://stackoverflow.com/questions/35560894/is-docker-arg-allowed-within-cmd-instruction (Environment variables are accessible within the CMD instruction at runtime.)
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+
 # Print the GLIBC version
 RUN ldd --version && \
 

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -7,7 +7,7 @@ COPY . .
 ARG PYTHON_VERSION="cp39-cp39"
 
 # Set PYTHON_VERSION as an environment variable.
-£ See https://stackoverflow.com/questions/35560894/is-docker-arg-allowed-within-cmd-instruction (Environment variables are accessible within the CMD instruction at runtime.)
+# See https://stackoverflow.com/questions/35560894/is-docker-arg-allowed-within-cmd-instruction (Environment variables are accessible within the CMD instruction at runtime.)
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 
 # Print the GLIBC version

--- a/python/Dockerfile.test
+++ b/python/Dockerfile.test
@@ -23,4 +23,4 @@ RUN ldd --version && \
    /opt/python/${PYTHON_VERSION}/bin/pip install PalletJack --pre --find-links ./dist --only-binary=:all: --force-reinstall --no-index --no-deps
 
 # Define the command to run tests
-CMD ["/opt/python/${PYTHON_VERSION}/bin/python", "./test/test_palletjack.py"]
+CMD "/opt/python/${PYTHON_VERSION}/bin/python" "./test/test_palletjack.py"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,14 +4,13 @@ requires = [
   "Cython>=3",
   "numpy>=1.16.6",
   "pyarrow~=21.0.0",
-  "thrift",
 ]
 
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "palletjack"
-version = "2.7.0"
+version = "2.8.0"
 description = "Faster parquet metadata reading"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -24,6 +23,7 @@ dependencies = [
   "pyarrow~=21.0.0",
 ]
 
+
 [tool.setuptools.packages.find]
 include = ['palletjack*']
 
@@ -33,3 +33,61 @@ include = ['palletjack*']
 [project.urls]
 Homepage = "https://github.com/G-Research/PalletJack"
 Issues = "https://github.com/G-Research/PalletJack/issues"
+
+########################### cibuildwheel ###########################
+[tool.cibuildwheel]
+skip = [
+ "*_i686", 
+ "*-musllinux_*",
+ "*win32",
+ "cp314-*",
+ "cp314t-*",
+]
+
+# We use manylinux_2_28 for ABI compatibility with pyarrow
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+
+########################### cibuildwheel Linux #####################
+[tool.cibuildwheel.linux]
+before-build = [
+  "pip install auditwheel",
+  "ldd --version", # This will show the glibc version being used
+  "python -c 'import sysconfig; print(sysconfig.get_config_var(\"CC\"))'", # Show the C compiler used
+  "python -c 'import platform; print(platform.libc_ver())'", # Show libc version Python sees
+  "ls -l /lib64/libc.so.6", # Another way to see glibc
+]
+
+repair-wheel-command = [
+ "auditwheel repair --exclude libarrow.so.2100 --exclude libparquet.so.2100 -w {dest_dir} {wheel}",
+]
+
+# Run multiple commands using an array
+before-all = [
+  "git clone --depth 1 --branch v0.19.0 https://github.com/apache/thrift.git",
+  "yum -y update",
+  "yum -y groupinstall 'Development Tools'",
+  "yum -y install libevent-devel zlib-devel openssl-devel boost-devel boost-static",
+  "cd thrift",
+  "./bootstrap.sh",
+  "CFLAGS='-fPIC' CXXFLAGS='-fPIC' ./configure --with-cpp=yes --with-python=no --with-py3=no --enable-tests=no --enable-tutorial=no --enable-shared=no",
+  "make",
+  "make install",
+]
+
+########################### cibuildwheel Windows ###################
+[tool.cibuildwheel.windows]
+before-build = "pip install delvewheel"
+repair-wheel-command = "delvewheel repair --exclude arrow.dll --exclude parquet.dll -w {dest_dir} {wheel}"
+before-all = [
+  "vcpkg install --x-manifest-root . --feature-flags=versions",
+]
+
+########################### cibuildwheel MacOS #####################
+[tool.cibuildwheel.macos]
+before-build = "pip install delocate"
+repair-wheel-command = ""
+
+before-all = [
+  "vcpkg install --x-manifest-root . --feature-flags=versions",
+]

--- a/python/setup.py
+++ b/python/setup.py
@@ -97,7 +97,7 @@ class GenerateMetadata(build_py):
         print(f"Generated metadata file: {metadata_file}")
         print (os.listdir(output_dir))
 
-        # Call the original build_py command
+        # Finally, call the original build_py command
         super().run()
 		
 # Make default named pyarrow shared libs available.

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -60,7 +60,7 @@ class TestPalletJack(unittest.TestCase):
             pj_data = pr.read_row_groups(list(range(0, len(row_groups))))
             self.assertEqual(org_data, pj_data, f"row_groups={row_groups}, column_indices={column_indices}")
 
-            # pr.close()
+            pr.close()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -60,7 +60,9 @@ class TestPalletJack(unittest.TestCase):
             pj_data = pr.read_row_groups(list(range(0, len(row_groups))))
             self.assertEqual(org_data, pj_data, f"row_groups={row_groups}, column_indices={column_indices}")
 
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            pr.close()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table()
 
@@ -78,7 +80,7 @@ class TestPalletJack(unittest.TestCase):
                             validate_reading(path, index_path, row_groups = rp, column_indices = cp)
 
     def test_metadata_roundtrip(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table()
 
@@ -89,36 +91,40 @@ class TestPalletJack(unittest.TestCase):
 
             pr = pq.ParquetReader()
             pr.open(path)
-            
+
             row_groups_columns = [
                 ([], []),
                 ([], range(n_columns)),
                 (range(n_row_groups), []),
                 (range(n_row_groups), range(n_columns)),
             ]
-            
+
             for (row_groups, columns) in row_groups_columns:
                 pj_metadata = pj.read_metadata(index_path, row_groups=row_groups, column_indices=columns)
                 self.assertEqual(pr.metadata, pj_metadata)
+
+            pr.close()
 
     def test_reading_non_pyarrow_files(self):
         
             path = os.path.join(current_dir, 'data/no_column_orders.parquet')
             pr = pq.ParquetReader()
             pr.open(path)
-            
+
             row_groups_columns = [
                 ([], []),
                 ([], range(pr.metadata.num_columns)),
                 (range(pr.metadata.num_row_groups), []),
                 (range(pr.metadata.num_row_groups), range(pr.metadata.num_columns)),
             ]
-            
+
             index_data = pj.generate_metadata_index(path)
             for (row_groups, columns) in row_groups_columns:
                 pj_metadata = pj.read_metadata(index_data = index_data, row_groups=row_groups, column_indices=columns)
                 self.assertEqual(pr.metadata, pj_metadata)
-                
+
+            pr.close()
+
     def test_reading_invalid_row_group(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
@@ -192,28 +198,30 @@ class TestPalletJack(unittest.TestCase):
             # Compare the actual output to the expected output
             self.assertEqual(actual_output, expected_output)
 
-        pr = pq.ParquetReader()
-        pr.open(path)
-        metadata = pr.metadata
-        row_groups = metadata.num_row_groups
-
-        for r in range(0, row_groups):
-
-            # Reading using the original metadata
             pr = pq.ParquetReader()
             pr.open(path)
-            res_data_org = pr.read_row_groups([r], use_threads=False)
+            metadata = pr.metadata
+            row_groups = metadata.num_row_groups
 
-            # Reading using the indexed metadata
-            metadata = pj.read_metadata(expected_index_path, row_groups = [r])
-            pr = pq.ParquetReader()
-            pr.open(path, metadata=metadata)
+            for r in range(0, row_groups):
 
-            res_data_index = pr.read_row_groups([0], use_threads=False)
-            self.assertEqual(res_data_org, res_data_index, f"Row={r}")
-  
+                # Reading using the original metadata
+                pr = pq.ParquetReader()
+                pr.open(path)
+                res_data_org = pr.read_row_groups([r], use_threads=False)
+
+                # Reading using the indexed metadata
+                metadata = pj.read_metadata(expected_index_path, row_groups = [r])
+                pr = pq.ParquetReader()
+                pr.open(path, metadata=metadata)
+
+                res_data_index = pr.read_row_groups([0], use_threads=False)
+                self.assertEqual(res_data_org, res_data_index, f"Row={r}")
+
+            pr.close()
+
     def test_inmemory_index_data(self):
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+        with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")
             table = get_table()
 

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -54,6 +54,8 @@ class TestPalletJack(unittest.TestCase):
             self.assertEqual(metadata, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
             self.assertEqual(metadata_names_data, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
 
+            pr.close()
+
             pr = pq.ParquetReader()
             pr.open(parquet_path, metadata=metadata)
 
@@ -202,6 +204,7 @@ class TestPalletJack(unittest.TestCase):
             pr.open(path)
             metadata = pr.metadata
             row_groups = metadata.num_row_groups
+            pr.close()
 
             for r in range(0, row_groups):
 
@@ -209,6 +212,7 @@ class TestPalletJack(unittest.TestCase):
                 pr = pq.ParquetReader()
                 pr.open(path)
                 res_data_org = pr.read_row_groups([r], use_threads=False)
+                pr.close()
 
                 # Reading using the indexed metadata
                 metadata = pj.read_metadata(expected_index_path, row_groups = [r])
@@ -217,8 +221,7 @@ class TestPalletJack(unittest.TestCase):
 
                 res_data_index = pr.read_row_groups([0], use_threads=False)
                 self.assertEqual(res_data_org, res_data_index, f"Row={r}")
-
-            pr.close()
+                pr.close()
 
     def test_inmemory_index_data(self):
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -60,7 +60,7 @@ class TestPalletJack(unittest.TestCase):
             pj_data = pr.read_row_groups(list(range(0, len(row_groups))))
             self.assertEqual(org_data, pj_data, f"row_groups={row_groups}, column_indices={column_indices}")
 
-            pr.close()
+            # pr.close()
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")


### PR DESCRIPTION
fixes https://github.com/G-Research/gr-oss/issues/1058
Due to a mistake in the CI, we ended up requiring glibc 2.35+.
Now we make sure that Palletjack works for all supported Python versions with glibc 2.28+.