### PR TITLE
Implement schema-only reading

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -105,3 +105,14 @@ pr.open(path, metadata=metadata)
 
 data = pr.read_all()
 ```
+
+### Reading the schema
+```
+schema = pj.read_schema(index_path)
+```
+
+### Reading the schema for a subset of columns:
+```
+schema = pj.read_schema(index_path, column_indices = [1, 3])
+schema = pj.read_schema(index_path, column_names = ['column_1', 'column_3'])
+```

--- a/python/palletjack/cpalletjack.pxd
+++ b/python/palletjack/cpalletjack.pxd
@@ -7,5 +7,5 @@ from pyarrow._parquet cimport *
 cdef extern from "palletjack.h":
     cdef vector[char] GenerateMetadataIndex(const char *parquet_path) except + nogil
     cdef void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path) except + nogil
-    cdef shared_ptr[CFileMetaData] ReadMetadata(const char *index_file_path, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) except + nogil
-    cdef shared_ptr[CFileMetaData] ReadMetadata(const unsigned char *index_data, size_t index_data_length, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) except + nogil
+    cdef shared_ptr[CFileMetaData] ReadMetadata(const char *index_file_path, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names, bint schema_only) except + nogil
+    cdef shared_ptr[CFileMetaData] ReadMetadata(const unsigned char *index_data, size_t index_data_length, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names, bint schema_only) except + nogil

--- a/python/palletjack/palletjack.cc
+++ b/python/palletjack/palletjack.cc
@@ -386,7 +386,8 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const DataHeader &dataHeader
                                                     size_t body_size,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
-                                                    const std::vector<std::string> &column_names)
+                                                    const std::vector<std::string> &column_names,
+                                                    bool schema_only)
 {
     if (memcmp(HEADER_V1, dataHeader.header, HEADER_V1_LENGTH) != 0)
     {
@@ -503,7 +504,8 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const DataHeader &dataHeader
         index_src = schema_elements[dataHeader.columns];
     }
 
-    if (row_groups.size() > 0)
+    auto row_group_filtering = row_groups.size() > 0 || schema_only;
+    if (row_group_filtering)
     {
         //> 3: required i64 num_rows
         int64_t num_rows = 0;
@@ -520,7 +522,6 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const DataHeader &dataHeader
         index_src = num_row_offsets[1];
     }
 
-    auto row_group_filtering = row_groups.size() > 0;
     if (row_group_filtering)
     {
         //> 4: required list<RowGroup> row_groups
@@ -632,7 +633,8 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const DataHeader &dataHeader
 std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
-                                                    const std::vector<std::string> &column_names)
+                                                    const std::vector<std::string> &column_names,
+                                                    bool schema_only)
 {
     auto f = std::unique_ptr<FILE, decltype(&fclose)>(fopen(index_file_path, "rb"), &fclose);
     if (!f)
@@ -665,14 +667,15 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
         throw std::logic_error(msg);
     }
 
-    return ReadMetadata(dataHeader, &data_body[0], body_size, row_groups, column_indices, column_names);
+    return ReadMetadata(dataHeader, &data_body[0], body_size, row_groups, column_indices, column_names, schema_only);
 }
 
 std::shared_ptr<parquet::FileMetaData> ReadMetadata(const unsigned char *index_data,
                                                     size_t index_data_length,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
-                                                    const std::vector<std::string> &column_names)
+                                                    const std::vector<std::string> &column_names,
+                                                    bool schema_only)
 {
     if (index_data_length < sizeof(DataHeader))
     {
@@ -688,5 +691,5 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const unsigned char *index_d
         throw std::logic_error(msg);
     }
 
-    return ReadMetadata(*p_data_header, &index_data[sizeof(DataHeader)], index_data_length - sizeof(DataHeader), row_groups, column_indices, column_names);
+    return ReadMetadata(*p_data_header, &index_data[sizeof(DataHeader)], index_data_length - sizeof(DataHeader), row_groups, column_indices, column_names, schema_only);
 }

--- a/python/palletjack/palletjack.h
+++ b/python/palletjack/palletjack.h
@@ -7,10 +7,12 @@ void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path
 std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
-                                                    const std::vector<std::string> &column_names);
+                                                    const std::vector<std::string> &column_names,
+                                                    bool schema_only = false);
 
 std::shared_ptr<parquet::FileMetaData> ReadMetadata(const unsigned char *index_data,
                                                     size_t index_data_length,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
-                                                    const std::vector<std::string> &column_names);
+                                                    const std::vector<std::string> &column_names,
+                                                    bool schema_only = false);

--- a/python/palletjack/palletjack_cython.pyi
+++ b/python/palletjack/palletjack_cython.pyi
@@ -1,7 +1,13 @@
 from typing import Optional, Sequence, overload
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 
+@overload
+def generate_metadata_index(
+    parquet_path: str,
+    index_file_path: str,
+) -> None: ...
 @overload
 def generate_metadata_index(
     parquet_path: str,
@@ -20,11 +26,6 @@ def generate_metadata_index(
     """
     ...
 
-@overload
-def generate_metadata_index(
-    parquet_path: str,
-    index_file_path: str,
-) -> None: ...
 def read_metadata(
     index_file_path: Optional[str] = None,
     row_groups: Sequence[int] = [],
@@ -48,5 +49,30 @@ def read_metadata(
     Returns:
         A :class:`pyarrow.parquet.FileMetaData` instance containing only the
         requested subset of metadata.
+    """
+    ...
+
+def read_schema(
+    index_file_path: Optional[str] = None,
+    column_indices: Sequence[int] = [],
+    column_names: Sequence[str] = [],
+    index_data: Optional[bytes] = None,
+) -> pa.Schema:
+    """Read the Arrow schema from a previously generated index.
+
+    Skips row-group decoding entirely.
+
+    Supply either *index_file_path* or *index_data*, not both.
+    *column_indices* and *column_names* are mutually exclusive.
+
+    Args:
+        index_file_path: Path to the index file on disk.
+        column_indices: Subset of column indices to read.
+        column_names: Subset of column names to read.
+        index_data: In-memory index bytes (e.g. from
+            :func:`generate_metadata_index`).
+
+    Returns:
+        A :class:`pyarrow.Schema` instance.
     """
     ...

--- a/python/palletjack/palletjack_cython.pyx
+++ b/python/palletjack/palletjack_cython.pyx
@@ -38,11 +38,32 @@ cpdef read_metadata(index_file_path = None, row_groups = [], column_indices = []
     if index_file_path is None:
         with cython.boundscheck(False):
             with nogil:
-                c_metadata = cpalletjack.ReadMetadata(&mv[0], len(mv), crow_groups, ccolumn_indices, ccolumn_names)
+                c_metadata = cpalletjack.ReadMetadata(&mv[0], len(mv), crow_groups, ccolumn_indices, ccolumn_names, False)
     else:
         with nogil:
-            c_metadata = cpalletjack.ReadMetadata(encoded_path.c_str(), crow_groups, ccolumn_indices, ccolumn_names)
+            c_metadata = cpalletjack.ReadMetadata(encoded_path.c_str(), crow_groups, ccolumn_indices, ccolumn_names, False)
 
     cdef FileMetaData m = FileMetaData.__new__(FileMetaData)
     m.init(c_metadata)
     return m
+
+cpdef read_schema(index_file_path = None, column_indices = [], column_names = [], index_data = None):
+
+    cdef shared_ptr[CFileMetaData] c_metadata
+    cdef string encoded_path = index_file_path.encode('utf8') if index_file_path is not None else "".encode('utf8')
+    cdef const unsigned char[::1] mv = index_data
+    cdef vector[uint32_t] crow_groups
+    cdef vector[uint32_t] ccolumn_indices = column_indices
+    cdef vector[string] ccolumn_names = [c.encode('utf8') for c in column_names]
+
+    if index_file_path is None:
+        with cython.boundscheck(False):
+            with nogil:
+                c_metadata = cpalletjack.ReadMetadata(&mv[0], len(mv), crow_groups, ccolumn_indices, ccolumn_names, True)
+    else:
+        with nogil:
+            c_metadata = cpalletjack.ReadMetadata(encoded_path.c_str(), crow_groups, ccolumn_indices, ccolumn_names, True)
+
+    cdef FileMetaData m = FileMetaData.__new__(FileMetaData)
+    m.init(c_metadata)
+    return m.schema.to_arrow_schema()

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -223,6 +223,75 @@ class TestPalletJack(unittest.TestCase):
                 self.assertEqual(res_data_org, res_data_index, f"Row={r}")
                 pr.close()
 
+    def test_read_schema(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table()
+
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+
+            index_path = path + '.index'
+            pj.generate_metadata_index(path, index_path)
+
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_schema = pr.metadata.schema.to_arrow_schema()
+            pr.close()
+
+            # Full schema from file
+            schema = pj.read_schema(index_path)
+            self.assertEqual(schema, expected_schema)
+
+            # Filtered by column_indices
+            for c in range(n_columns):
+                schema_col = pj.read_schema(index_path, column_indices=[c])
+                self.assertEqual(len(schema_col), 1)
+                self.assertEqual(schema_col.field(0), expected_schema.field(c))
+
+            # Filtered by column_names
+            for c in range(n_columns):
+                name = f'column_{c}'
+                schema_name = pj.read_schema(index_path, column_names=[name])
+                self.assertEqual(len(schema_name), 1)
+                self.assertEqual(schema_name.field(0).name, name)
+
+            # Multiple columns
+            indices = [0, 2, 4]
+            schema_multi = pj.read_schema(index_path, column_indices=indices)
+            self.assertEqual(len(schema_multi), len(indices))
+            for i, idx in enumerate(indices):
+                self.assertEqual(schema_multi.field(i), expected_schema.field(idx))
+
+    def test_read_schema_errors(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table()
+
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+
+            index_path = path + '.index'
+            pj.generate_metadata_index(path, index_path)
+
+            with self.assertRaises(RuntimeError):
+                pj.read_schema(index_path, column_indices=[n_columns])
+
+            with self.assertRaises(RuntimeError):
+                pj.read_schema(index_path, column_names=["no_such_column"])
+
+            with self.assertRaises(RuntimeError):
+                pj.read_schema(index_path, column_indices=[0], column_names=["column_0"])
+
+    def test_read_schema_non_pyarrow_files(self):
+            path = os.path.join(current_dir, 'data/no_column_orders.parquet')
+            pr = pq.ParquetReader()
+            pr.open(path)
+            expected_schema = pr.metadata.schema.to_arrow_schema()
+            pr.close()
+
+            index_data = pj.generate_metadata_index(path)
+            schema = pj.read_schema(index_data=index_data)
+            self.assertEqual(schema, expected_schema)
+
     def test_inmemory_index_data(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "my.parquet")

--- a/python/test/test_readme.py
+++ b/python/test/test_readme.py
@@ -80,3 +80,14 @@ pr.open(path, metadata=metadata)
 
 data = pr.read_all()
 # ```
+
+### Reading the schema
+# ```
+schema = pj.read_schema(index_path)
+# ```
+
+### Reading the schema for a subset of columns:
+# ```
+schema = pj.read_schema(index_path, column_indices = [1, 3])
+schema = pj.read_schema(index_path, column_names = ['column_1', 'column_3'])
+# ```


### PR DESCRIPTION
Summary
  - Adds a new `read_schema()` function that returns a` pa.Schema `without decoding row group metadata
  - `read_schema` supports optional `column_names` or `column_indices` parameters to read a subset of columns.
  - Existing `read_metadata` behavior is unchanged