### PR TITLE
Better error messages for encrypted metadata

### DIFF
--- a/python/palletjack/palletjack.cc
+++ b/python/palletjack/palletjack.cc
@@ -214,6 +214,12 @@ std::shared_ptr<arrow::Buffer> GenerateMetadataIndex(const char *parquet_path)
         PARQUET_ASSIGN_OR_THROW(infile, arrow::io::ReadableFile::Open(std::string(parquet_path)));
         auto metadata = parquet::ReadMetaData(infile);
 
+        if (metadata->is_encryption_algorithm_set())
+        {
+            throw parquet::ParquetException(
+                "Encrypted column metadata is not supported: '" + std::string(parquet_path) + "'.");
+        }
+
         std::shared_ptr<arrow::io::BufferOutputStream> metadata_stream;
         PARQUET_ASSIGN_OR_THROW(metadata_stream, arrow::io::BufferOutputStream::Create(1024, arrow::default_memory_pool()));
         metadata.get()->WriteTo(metadata_stream.get());

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palletjack"
-version = "2.12.1"
+version = "2.12.2"
 description = "Faster parquet metadata reading"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/setup.py
+++ b/python/setup.py
@@ -44,10 +44,9 @@ extra_link_args = []
 debug = False,
 
 if os.getenv('DEBUG', '') == 'ON':
-    print("Building with DEBUG information!")
-    extra_compile_args.extend(["-O0", "-DDEBUG"])
-    extra_link_args.extend(["-debug:full"])
-    debug = True
+    extra_compile_args = ["-Og", '-DDEBUG']
+    extra_link_args = ["-debug:full"]
+    debug = True,
 
 # Define your extension
 extensions = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -44,9 +44,10 @@ extra_link_args = []
 debug = False,
 
 if os.getenv('DEBUG', '') == 'ON':
-    extra_compile_args = ["-Og", '-DDEBUG']
-    extra_link_args = ["-debug:full"]
-    debug = True,
+    print("Building with DEBUG information!")
+    extra_compile_args.extend(["-O0", "-DDEBUG"])
+    extra_link_args.extend(["-debug:full"])
+    debug = True
 
 # Define your extension
 extensions = [

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -331,22 +331,6 @@ class TestPalletJack(unittest.TestCase):
             # Compare the actual output to the expected output
             self.assertEqual(index_data1, index_data2)
 
-    def test_encrypted_footer_no_key(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            path = os.path.join(tmpdirname, "encrypted_footer.parquet")
-            table = get_table()
-            enc_config = pe.EncryptionConfiguration(
-                footer_key='footer_key',
-                uniform_encryption=True,
-                plaintext_footer=False,
-            )
-            props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
-            pq.write_table(table, path, encryption_properties=props)
-
-            with self.assertRaises(RuntimeError) as context:
-                pj.generate_metadata_index(path)
-            self.assertIn("encrypted footer", str(context.exception))
-
     def test_encrypted_footer_parquet(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             path = os.path.join(tmpdirname, "encrypted_footer.parquet")
@@ -359,16 +343,9 @@ class TestPalletJack(unittest.TestCase):
             enc_props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
             pq.write_table(table, path, row_group_size=chunk_size, encryption_properties=enc_props)
 
-            dec_config = pe.DecryptionConfiguration(cache_lifetime=300)
-            dec_props = crypto_factory.file_decryption_properties(get_kms_connection_config(), dec_config)
-
-            index_data = pj.generate_metadata_index(path, decryption_properties=dec_props)
-            self.assertIsNotNone(index_data)
-
-            metadata = pj.read_metadata(index_data=index_data)
-            self.assertEqual(metadata.num_row_groups, n_row_groups)
-            self.assertEqual(metadata.num_columns, n_columns)
-
+            with self.assertRaises(RuntimeError) as context:
+                pj.generate_metadata_index(path)
+            self.assertIn("Could not read encrypted metadata, no decryption found in reader's properties", str(context.exception))
 
     def test_encrypted_column_metadata_parquet(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -382,12 +359,9 @@ class TestPalletJack(unittest.TestCase):
             props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
             pq.write_table(table, path, row_group_size=chunk_size, encryption_properties=props)
 
-            index_data = pj.generate_metadata_index(path)
-            self.assertIsNotNone(index_data)
-
-            metadata = pj.read_metadata(index_data=index_data)
-            self.assertEqual(metadata.num_row_groups, n_row_groups)
-            self.assertEqual(metadata.num_columns, n_columns)
+            with self.assertRaises(RuntimeError) as context:
+                pj.generate_metadata_index(path)
+            self.assertIn("Encrypted column metadata is not supported:", str(context.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -98,11 +98,11 @@ class TestPalletJack(unittest.TestCase):
             index_path = path + '.index'
             pj.generate_metadata_index(path, index_path)
 
-            all_columns = list(range(0, n_columns))
-            all_row_groups = list(range(0, n_row_groups))
-            for r in range(0, 4):
+            all_columns = list(range(n_columns))
+            all_row_groups = list(range(n_row_groups))
+            for r in range(3):
                 for rp in it.permutations(all_row_groups, r):
-                    for c in range(0, 4):
+                    for c in range(3):
                         for cp in it.permutations(all_columns, c):
                             validate_reading(path, index_path, row_groups = rp, column_indices = cp)
 

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -1,8 +1,10 @@
 import unittest
 import tempfile
+import base64
 
 import palletjack as pj
 import pyarrow.parquet as pq
+import pyarrow.parquet.encryption as pe
 import pyarrow as pa
 import numpy as np
 import itertools as it
@@ -13,6 +15,29 @@ n_row_groups = 5
 n_columns = 7
 chunk_size = 1 # One row group per chunk
 current_dir = os.path.dirname(os.path.realpath(__file__))
+
+class InMemoryKmsClient(pe.KmsClient):
+    def __init__(self, config):
+        super().__init__()
+        self.master_keys = config.custom_kms_conf
+
+    def wrap_key(self, key_bytes, master_key_identifier):
+        master = self.master_keys[master_key_identifier].encode()
+        padded = master * (len(key_bytes) // len(master) + 1)
+        return base64.b64encode(bytes(a ^ b for a, b in zip(key_bytes, padded[:len(key_bytes)]))).decode()
+
+    def unwrap_key(self, wrapped_key, master_key_identifier):
+        key_bytes = base64.b64decode(wrapped_key)
+        master = self.master_keys[master_key_identifier].encode()
+        padded = master * (len(key_bytes) // len(master) + 1)
+        return bytes(a ^ b for a, b in zip(key_bytes, padded[:len(key_bytes)]))
+
+crypto_factory = pe.CryptoFactory(lambda config: InMemoryKmsClient(config))
+
+def get_kms_connection_config():
+    config = pe.KmsConnectionConfig()
+    config.custom_kms_conf = {'footer_key': 'masterkey1234567', 'col_key': 'colmaster1234567'}
+    return config
 
 def get_table():
     # Generate a random 2D array of floats using NumPy
@@ -306,5 +331,65 @@ class TestPalletJack(unittest.TestCase):
             # Compare the actual output to the expected output
             self.assertEqual(index_data1, index_data2)
 
+    def test_encrypted_footer_no_key(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "encrypted_footer.parquet")
+            table = get_table()
+            enc_config = pe.EncryptionConfiguration(
+                footer_key='footer_key',
+                uniform_encryption=True,
+                plaintext_footer=False,
+            )
+            props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
+            pq.write_table(table, path, encryption_properties=props)
+
+            with self.assertRaises(RuntimeError) as context:
+                pj.generate_metadata_index(path)
+            self.assertIn("encrypted footer", str(context.exception))
+
+    def test_encrypted_footer_parquet(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "encrypted_footer.parquet")
+            table = get_table()
+            enc_config = pe.EncryptionConfiguration(
+                footer_key='footer_key',
+                uniform_encryption=True,
+                plaintext_footer=False,
+            )
+            enc_props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
+            pq.write_table(table, path, row_group_size=chunk_size, encryption_properties=enc_props)
+
+            dec_config = pe.DecryptionConfiguration(cache_lifetime=300)
+            dec_props = crypto_factory.file_decryption_properties(get_kms_connection_config(), dec_config)
+
+            index_data = pj.generate_metadata_index(path, decryption_properties=dec_props)
+            self.assertIsNotNone(index_data)
+
+            metadata = pj.read_metadata(index_data=index_data)
+            self.assertEqual(metadata.num_row_groups, n_row_groups)
+            self.assertEqual(metadata.num_columns, n_columns)
+
+
+    def test_encrypted_column_metadata_parquet(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            path = os.path.join(tmpdirname, "encrypted_plaintext_footer.parquet")
+            table = get_table()
+            enc_config = pe.EncryptionConfiguration(
+                footer_key='footer_key',
+                column_keys={'col_key': [f'column_{i}' for i in range(n_columns)]},
+                plaintext_footer=True,
+            )
+            props = crypto_factory.file_encryption_properties(get_kms_connection_config(), enc_config)
+            pq.write_table(table, path, row_group_size=chunk_size, encryption_properties=props)
+
+            index_data = pj.generate_metadata_index(path)
+            self.assertIsNotNone(index_data)
+
+            metadata = pj.read_metadata(index_data=index_data)
+            self.assertEqual(metadata.num_row_groups, n_row_groups)
+            self.assertEqual(metadata.num_columns, n_columns)
+
 if __name__ == '__main__':
     unittest.main()
+    # unittest.main(argv=['first-arg-is-ignored', '-k', 'TestPalletJack.test_encrypted_footer_parquet'])
+

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -98,11 +98,11 @@ class TestPalletJack(unittest.TestCase):
             index_path = path + '.index'
             pj.generate_metadata_index(path, index_path)
 
-            all_columns = list(range(n_columns))
-            all_row_groups = list(range(n_row_groups))
-            for r in range(3):
+            all_columns = list(range(0, n_columns))
+            all_row_groups = list(range(0, n_row_groups))
+            for r in range(0, 4):
                 for rp in it.permutations(all_row_groups, r):
-                    for c in range(3):
+                    for c in range(0, 4):
                         for cp in it.permutations(all_columns, c):
                             validate_reading(path, index_path, row_groups = rp, column_indices = cp)
 
@@ -365,5 +365,3 @@ class TestPalletJack(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    # unittest.main(argv=['first-arg-is-ignored', '-k', 'TestPalletJack.test_encrypted_footer_parquet'])
-


### PR DESCRIPTION
Add an explicit check for encrypted column metadata in `GenerateMetadataIndex`. Files with plaintext footers but encrypted columns were previously failing with a segfault during metadata deserialization. Now they fail early with a message that includes the file path.
Fully encrypted footers (non-plaintext) are already rejected by Arrow's `ReadMetaData `before reaching this check.